### PR TITLE
(GH-145) Migrate from FxCop analyzers to NETAnalyzers

### DIFF
--- a/src/Cake.Issues.EsLint/Cake.Issues.EsLint.csproj
+++ b/src/Cake.Issues.EsLint/Cake.Issues.EsLint.csproj
@@ -11,7 +11,8 @@
 
   <PropertyGroup>
     <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>    
+    <DebugSymbols>true</DebugSymbols>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.EsLint.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
@@ -26,7 +27,10 @@
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Issues" Version="0.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
FxCopAnalyzers package has been deprecated in favor of 'Microsoft.CodeAnalysis.NetAnalyzers'.

Add **AllEnabledByDefault**
Aggressive or opt-out mode, where all rules are enabled by default as build warnings. You can selectively opt out of individual rules to disable them.
