### PR TITLE
(GH-174) Multi-Target .NET Core 3.1, 5 & 6 instead of .NET Standard 2.0

### DIFF
--- a/nuspec/nuget/Cake.Issues.EsLint.nuspec
+++ b/nuspec/nuget/Cake.Issues.EsLint.nuspec
@@ -28,8 +28,14 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netstandard2.0\Cake.Issues.EsLint.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Issues.EsLint.pdb" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Issues.EsLint.xml" target="lib\netstandard2.0" />
+    <file src="netcoreapp3.1\Cake.Issues.EsLint.dll" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1\Cake.Issues.EsLint.pdb" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1\Cake.Issues.EsLint.xml" target="lib\netcoreapp3.1" />
+    <file src="net5.0\Cake.Issues.EsLint.dll" target="lib\net5.0" />
+    <file src="net5.0\Cake.Issues.EsLint.pdb" target="lib\net5.0" />
+    <file src="net5.0\Cake.Issues.EsLint.xml" target="lib\net5.0" />
+    <file src="net6.0\Cake.Issues.EsLint.dll" target="lib\net6.0" />
+    <file src="net6.0\Cake.Issues.EsLint.pdb" target="lib\net6.0" />
+    <file src="net6.0\Cake.Issues.EsLint.xml" target="lib\net6.0" />
   </files>
 </package>

--- a/src/Cake.Issues.EsLint.Tests/Cake.Issues.EsLint.Tests.csproj
+++ b/src/Cake.Issues.EsLint.Tests/Cake.Issues.EsLint.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © BBT Software AG and contributors</Copyright>
@@ -10,11 +10,9 @@
     <Company>BBT Software AG</Company>
   </PropertyGroup>
 
-
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\Cake.Issues.EsLint.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-
 
   <ItemGroup>
     <None Remove="Testfiles\JsonLogFileFormat\issueWithoutLineAndColumn.json" />
@@ -22,13 +20,11 @@
     <None Remove="Testfiles\JsonLogFileFormat\jsonFormatWindows.json" />
   </ItemGroup>
 
-
   <ItemGroup>
     <EmbeddedResource Include="Testfiles\JsonLogFileFormat\issueWithoutLineAndColumn.json" />
     <EmbeddedResource Include="Testfiles\JsonLogFileFormat\issueWithoutRule.json" />
     <EmbeddedResource Include="Testfiles\JsonLogFileFormat\jsonFormatWindows.json" />
   </ItemGroup>
-
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />

--- a/src/Cake.Issues.EsLint/Cake.Issues.EsLint.csproj
+++ b/src/Cake.Issues.EsLint/Cake.Issues.EsLint.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>EsLint support for the Cake.Issues Addin for Cake Build Automation System</Description>
     <Authors>BBT Software AG</Authors>
     <Company>BBT Software AG</Company>
@@ -15,14 +15,7 @@
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.EsLint.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard1.6\Cake.Issues.EsLint.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.6\Cake.Issues.EsLint.xml</DocumentationFile>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.EsLint.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Multi-Target .NET Core 3.1, 5, & 6 to follow best-practices for Cake 2.0.

Fixes #174 