### PR TITLE
Update Dependabot configuration to ignore Cake 2.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,46 +9,13 @@ updates:
   ignore:
   - dependency-name: Cake.Core
     versions:
-    - ">= 0.34.a, < 0.35"
-  - dependency-name: Cake.Core
+    - "(,3.0)"
+  - dependency-name: Cake.Testing
     versions:
-    - ">= 0.35.a, < 0.36"
-  - dependency-name: Cake.Core
-    versions:
-    - ">= 0.36.a, < 0.37"
-  - dependency-name: Cake.Core
-    versions:
-    - ">= 0.37.a, < 0.38"
-  - dependency-name: Cake.Core
-    versions:
-    - ">= 0.38.a, < 0.39"
-  - dependency-name: Cake.Core
-    versions:
-    - "> 1.0.0, < 2"
+    - "(,3.0)"
   - dependency-name: Cake.Issues
     versions:
-    - "> 0.9.0, < 0.10"
+    - "> 1.0.0, < 2"
   - dependency-name: Cake.Issues.Testing
     versions:
-    - "> 0.9.0, < 0.10"
-  - dependency-name: Cake.Testing
-    versions:
-    - ">= 0.34.a, < 0.35"
-  - dependency-name: Cake.Testing
-    versions:
-    - ">= 0.35.a, < 0.36"
-  - dependency-name: Cake.Testing
-    versions:
-    - ">= 0.36.a, < 0.37"
-  - dependency-name: Cake.Testing
-    versions:
-    - ">= 0.37.a, < 0.38"
-  - dependency-name: Cake.Testing
-    versions:
-    - ">= 0.38.a, < 0.39"
-  - dependency-name: Cake.Testing
-    versions:
     - "> 1.0.0, < 2"
-  - dependency-name: Cake.Testing
-    versions:
-    - 1.0.0


### PR DESCRIPTION
Update Dependabot configuration to ignore Cake 2.x